### PR TITLE
Tira avatar do Aurelio do rodapé

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -54,8 +54,6 @@
 
 </div><!--main-->
 
-<a class="cabecao" href="http://aurelio.net" title="AURELIO.NET — Organizações Verde Inc.™"><img src="http://aurelio.net/include/10anos/aureliolga.jpg"></a>
-
 <!-- Google Analytics -->
 <script>
   (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){

--- a/css/site.css
+++ b/css/site.css
@@ -190,21 +190,6 @@ table {
     font-size: 15px;
 }
 
-/* ------------------------- my head */
-
-.cabecao {
-    position: fixed;
-    right: 0;
-    bottom: 0;
-}
-.cabecao img {
-    padding: 2px;
-    width: 38px;
-    height: 45px;
-    /* orig: 57x68 */
-}
-
-
 
 
 /****************************************************************************/


### PR DESCRIPTION
Isso é de uma época em que eu era o único autor do software. Hoje tem o Itamar também, então não faz sentido deixar ali.